### PR TITLE
Updates the documentation URL in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ are not covered by Symfony's
 Resources
 ---------
 
- * [Documentation](https://symfony.com/doc/current/components/asset_mapper/introduction.html)
+ * [Documentation](https://symfony.com/doc/current/frontend/asset_mapper.html)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
Documentation has moved from https://symfony.com/doc/current/components/asset_mapper/introduction.html to https://symfony.com/doc/current/frontend/asset_mapper.html. The current link URL throws a 404.