### PR TITLE
feat: Added logical failure implementation

### DIFF
--- a/Command/ImportMapInstallCommand.php
+++ b/Command/ImportMapInstallCommand.php
@@ -42,18 +42,24 @@ final class ImportMapInstallCommand extends Command
         $finishedCount = 0;
         $progressBar = new ProgressBar($output);
         $progressBar->setFormat('<info>%current%/%max%</info> %bar% %url%');
-        $downloadedPackages = $this->packageDownloader->downloadPackages(function (string $package, string $event, ResponseInterface $response, int $totalPackages) use (&$finishedCount, $progressBar) {
-            $progressBar->setMessage($response->getInfo('url'), 'url');
-            if (0 === $progressBar->getMaxSteps()) {
-                $progressBar->setMaxSteps($totalPackages);
-                $progressBar->start();
-            }
+        try {
+            $downloadedPackages = $this->packageDownloader->downloadPackages(function (string $package, string $event, ResponseInterface $response, int $totalPackages) use (&$finishedCount, $progressBar) {
+                $progressBar->setMessage($response->getInfo('url'), 'url');
+                if (0 === $progressBar->getMaxSteps()) {
+                    $progressBar->setMaxSteps($totalPackages);
+                    $progressBar->start();
+                }
 
-            if ('finished' === $event) {
-                ++$finishedCount;
-                $progressBar->advance();
-            }
-        });
+                if ('finished' === $event) {
+                    ++$finishedCount;
+                    $progressBar->advance();
+                }
+            });
+        } catch (\Throwable $throwable) {
+            $io->error($throwable->getMessage());
+
+            return Command::FAILURE;
+        }
         $progressBar->finish();
         $progressBar->clear();
 


### PR DESCRIPTION
Good morning,

I am opening this PR with a somewhat small change that will allow us to get correct exit codes when the `importmap:install` is being run and one of the exceptions is thrown.
Currently, when I run `importmap:install` and the one of the exceptions is thrown I am not getting any output at all and the exit code is always `0`.

Thanks in advance for looking at this pr and have a nice day.